### PR TITLE
LAP4CAI-135: GL as a development team we want to modify the retake quiz feature to preserve and display user s previous answers allowing for easy modifications

### DIFF
--- a/src/components/Dropdown/Dropdown.jsx
+++ b/src/components/Dropdown/Dropdown.jsx
@@ -1,15 +1,15 @@
-import React from "react";
+import React, { useEffect } from "react";
 import "./Dropdown.scss";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
-const Dropdown = ({
-  dropDownInfo1,
-  labelName,
-  onChangeDropdown,
-  question_id,
-}) => {
-  const [updatedValue, setUpdatedValue] = React.useState();
+const Dropdown = ({ dropDownInfo1, labelName, onChangeDropdown, value, question_id }) => {
+  const [updatedValue, setUpdatedValue] = React.useState(value);
   const [dummyValue, setDummyValue] = React.useState("Please select an option");
   const [isActive, setIsActive] = React.useState(false);
+
+  //add updatedValue if Session Storage has it
+  useEffect(() => {
+    setUpdatedValue(value);
+  }, [value]);
 
   const handleupdatedvalue = (event) => {
     setUpdatedValue(event.target.innerHTML);
@@ -37,9 +37,7 @@ const Dropdown = ({
             <span>
               <ArrowDropDownIcon
                 onClick={handledropdownclick}
-                className={`arrow ${
-                  isActive ? "arrow-up-icon" : "arrow-down-icon"
-                }`}
+                className={`arrow ${isActive ? "arrow-up-icon" : "arrow-down-icon"}`}
               />
             </span>
           </div>

--- a/src/components/DropdownCheckbox/DropdownCheckbox.jsx
+++ b/src/components/DropdownCheckbox/DropdownCheckbox.jsx
@@ -1,12 +1,12 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import "./DropdownCheckbox.scss";
 
-const DropdownCheckbox = ({
-  onChangeDropdownCheckbox,
-  labelName,
-  options1,
-}) => {
+const DropdownCheckbox = ({ onChangeDropdownCheckbox, labelName, options1, values }) => {
   const [selectedValues, setSelectedValues] = useState([]);
+
+  useEffect(() => {
+    setSelectedValues(values);
+  }, [values]);
 
   const isMoreThanSix = options1.length > 6;
 

--- a/src/components/QuizPage/QuizPage.jsx
+++ b/src/components/QuizPage/QuizPage.jsx
@@ -1,18 +1,30 @@
 import "./QuizPage.scss";
 import ProgressBar from "../../components/ProgressBar/ProgressBar";
-import React, { useState, Suspense } from "react";
+import React, { useState, Suspense, useEffect } from "react";
 import QuizQuestions from "../../components/QuizQuestions/QuizQuestions";
 import LoadingPage from "../LoadingPage/LoadingPage";
 import NoMatch from "../NoMatch/NoMatch";
 import MatchedUsers from "../MatchedUsers/MatchedUsers";
 
 const QuizPage = ({ currentPage, setCurrentPage }) => {
+  useEffect(() => {
+    console.log("QuizPage mounted");
+    return () => {
+      console.log("QuizPage unmounted");
+    };
+  }, []);
+
   const step = 1;
-  const [progress, setProgress] = useState(0);
+  const [progress, setProgress] = useState(() => {
+    const savedProgress = sessionStorage.getItem("progress");
+    return savedProgress ? Number(savedProgress) : 0;
+  });
   const onProgressChange = (answeredQuestionsCount) => {
-    //console.log("Answered Questions Count:", answeredQuestionsCount);
+    console.log("Answered Questions Count:", answeredQuestionsCount);
     // Update progress based on the number of answered questions
     setProgress(answeredQuestionsCount);
+    //store progress in session storage
+    sessionStorage.setItem("progress", answeredQuestionsCount);
   };
 
   return (

--- a/src/components/QuizQuestions/QuizQuestions.jsx
+++ b/src/components/QuizQuestions/QuizQuestions.jsx
@@ -21,13 +21,13 @@ const QuizQuestions = ({ setCurrentPage, onProgressChange }) => {
     //get from session storage
     return { ...initialFormData, ...getSessionData() };
   });
+  //all answers required except Q12
   const requiredQuestionIds = [
     "001",
     "002",
     "003",
     "004",
     "005",
-    "006",
     "006",
     "007",
     "008",
@@ -36,7 +36,7 @@ const QuizQuestions = ({ setCurrentPage, onProgressChange }) => {
     "011",
   ];
   const [selectedAnswerIds, setSelectedAnswerIds] = useState([]);
-  const [answeredQuestions, setAnsweredQuestions] = React.useState(new Set());
+  const [answeredQuestions, setAnsweredQuestions] = useState(new Set());
 
   //try to set formData to session storage
   useEffect(() => {

--- a/src/components/Textarea/Textarea.jsx
+++ b/src/components/Textarea/Textarea.jsx
@@ -1,10 +1,15 @@
-import React from "react";
+import { useState, useEffect } from "react";
 import "./Textarea.scss";
 
-const Textarea = ({ labelName, handleTextarea }) => {
-  const [value, setValue] = React.useState("");
+const Textarea = ({ labelName, handleTextarea, value }) => {
+  const [textValue, setTextValue] = useState("");
+
+  useEffect(() => {
+    setTextValue(value);
+  }, [value]);
+
   const handleChange = (e) => {
-    setValue(e.target.value);
+    setTextValue(e.target.value);
     handleTextarea(e.target.value);
   };
   return (
@@ -16,7 +21,7 @@ const Textarea = ({ labelName, handleTextarea }) => {
         className="textarea__input"
         name=""
         id="input"
-        value={value}
+        value={textValue}
         onChange={handleChange}
       ></textarea>
     </div>

--- a/src/index.js
+++ b/src/index.js
@@ -5,9 +5,13 @@ import { BrowserRouter } from "react-router-dom";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
-  <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
-  </React.StrictMode>
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>
+
+  // <React.StrictMode>
+  //   <BrowserRouter>
+  //     <App />
+  //   </BrowserRouter>
+  // </React.StrictMode>
 );

--- a/src/pages/QuizPage/QuizPage.jsx
+++ b/src/pages/QuizPage/QuizPage.jsx
@@ -116,7 +116,7 @@ const QuizPage = () => {
             </section>
           
           </form> */}
-          <QuizQuestions/>
+          <QuizQuestions />
         </div>
       </div>
     </div>
@@ -124,4 +124,3 @@ const QuizPage = () => {
 };
 
 export default QuizPage;
-


### PR DESCRIPTION
JIRA Ticket link: (https://makeitmvp.atlassian.net/browse/LAP4CAI-135?atlOrigin=eyJpIjoiNDgxYTc0YTdjZTAxNGZhMjk4MzI2ZmYyYTRiNzM4MjQiLCJwIjoiaiJ9)

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactoring

## Description

- Changes made? Added session storage capability to store formData and progress, so refreshing doesn't reset the answered questions and progress bar status. All quiz questions (11/12) except for the text area are now required to be answered.
- Reason for changes? Refreshing caused user to redo all questions again. User would be able to move on without answering 11/12 questions.
- Behavior before? Refreshing caused user to redo all questions again. User would be able to move on without answering 11/12 questions.
- Behavior after? Refreshing allows answered questions to persist. User can only move on after 11/12 questions have been answered.
- How did you test? Locally.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested the new feature and found it to be working as expected.
- [x] All commits in this PR are related to the issue.
- [x] Base branch for this PR is set to `develop`.
- [x] JIRA ticket # and my initials are noted in this PR's name (format example: #57-EB Add Pull Request template)

**Reminder**: every PR needs at least 1 peer approval before merging to the `develop` branch. Once a main ticket has been completed, along with all subtasks, associated code can be merged to `main`.
